### PR TITLE
set flexShrink for tabs

### DIFF
--- a/plugin/ui.tsx
+++ b/plugin/ui.tsx
@@ -846,6 +846,7 @@ class App extends SafeComponent {
             style={{
               minHeight: "auto",
               backgroundColor: "#F9F9F9",
+              flexShrink: 0,
             }}
             value={this.tabIndex}
             onChange={this.switchTab}


### PR DESCRIPTION
Setting flexShrink to 0 for tabs

Before

<img width="324" alt="image" src="https://user-images.githubusercontent.com/105281401/181213816-329d4f03-a5bb-49b2-b145-83e8ee2a9fd9.png">


After
<img width="324" alt="image" src="https://user-images.githubusercontent.com/105281401/181213529-9d38f9a6-86b1-48ee-99f9-d76fe5636d87.png">
