### PR TITLE
updates the old extension URL

### DIFF
--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -4,15 +4,15 @@
 
 ## Usage
 
-1) Install the Then the [chrome extension](https://chrome.google.com/webstore/detail/efjcmgblfpkhbjpkpopkgeomfkokpaim)
+1. Install the Then the [chrome extension](https://chromewebstore.google.com/detail/builderio/cfldfgibklhmjhnkfighkbafbkbfcmij)
 
-2) Go to a page, click the extension icon, and choose "capture current page"
+2. Go to a page, click the extension icon, and choose "capture current page"
 
-3) Open figma and be sure you have the [figma plugin](https://www.figma.com/c/plugin/747985167520967365/HTML-To-Figma) installed
+3. Open figma and be sure you have the [figma plugin](https://www.figma.com/c/plugin/747985167520967365/HTML-To-Figma) installed
 
-4) Hit command + / and type "html figma" and hit enter
+4. Hit command + / and type "html figma" and hit enter
 
-5) Choose "upload here" and upload the file downloaded by the extension
+5. Choose "upload here" and upload the file downloaded by the extension
 
 <img src="https://imgur.com/ARz16KC.gif" alt="Chrome extension demo" width="480" />
 


### PR DESCRIPTION
This is a small fix that confused me when I was trying to set up by following the README.

Old URL in `chrome-extension/README.md`.

<img width="1331" height="435" alt="image" src="https://github.com/user-attachments/assets/784fa892-2c6a-4c69-ab56-53e134bc3af8" />



Updated URL

<img width="1331" height="727" alt="image" src="https://github.com/user-attachments/assets/89523a58-904e-41a7-9680-3b43ae8fc505" />
